### PR TITLE
Add support for Slack incoming webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,27 @@ Using Slack incoming webhooks
 [See the Common Fate documentation here](https://docs.commonfate.io/common-fate/configuration/slack#setup-instructions---slack-webhooks). Add the following variable to your module configuration:
 
 ```hcl
-slack_incoming_webhook_urls = {
-    channel_name = "https://hooks.slack.com/services/WEBHOOK_SUFFIX"
-}
+slack_incoming_webhook_urls = ["channel_name"]
 ```
 
-Where `channel_name` is the identifier for your channel.
+Where `channel_name` is the identifier for your channel, like "common-fate-requests".
+
+The Terraform module will create an SSM parameter as follows:
+
+```
+/<SSM Parameter Prefix, i.e. common-fate>/secrets/notifications/slackIncomingWebhooks/<channel name>/webhookUrl
+```
+
+In the above example if `common-fate-requests` is used as the channel identifier, the SSM parameter would be something like:
+
+```
+/common-fate/secrets/notifications/slackIncomingWebhooks/common-fate-requests/webhookUrl
+```
+
+The SSM Parameter prefix is `common-fate` by default, but can be overridden by providing the `ssm_parameter_prefix` module variable.
+
+You will need to set the SSM parameter with the actual webhook value. You can do this as follows:
+
+```
+aws ssm put-parameter --name /common-fate/secrets/notifications/slackIncomingWebhooks/common-fate-requests/webhookUrl --value https://hooks.slack.com/services/XXXX/XXXXXX --type SecureString --overwrite
+```

--- a/README.md
+++ b/README.md
@@ -165,3 +165,16 @@ $ ./bin/terraform.sh -p <PROJECT> -g <GROUP> -e <ENVIRONMENT> -c sso -a apply
 $ aws ssm put-parameter --name '/<SSM Parameter Prefix, i.e. common-fate>/secrets/identity/token' --value '<VALUE FROM STEP 1.5.b>' --type SecureString --overwrite
 $ aws ssm put-parameter --name '/<SSM Parameter Prefix, i.e. common-fate>/secrets/notifications/slack/token' --value '<VALUE FROM STEP 6.3>' --type SecureString --overwrite
 ```
+
+Using Slack incoming webhooks
+=============================
+
+[See the Common Fate documentation here](https://docs.commonfate.io/common-fate/configuration/slack#setup-instructions---slack-webhooks). Add the following variable to your module configuration:
+
+```hcl
+slack_incoming_webhook_urls = {
+    channel_name = "https://hooks.slack.com/services/WEBHOOK_SUFFIX"
+}
+```
+
+Where `channel_name` is the identifier for your channel.

--- a/data_iam_policy_document_parameter_store_secrets_notifications_read.tf
+++ b/data_iam_policy_document_parameter_store_secrets_notifications_read.tf
@@ -8,9 +8,10 @@ data "aws_iam_policy_document" "parameter_store_secrets_notifications_read" {
       "ssm:GetParameters",
     ]
 
-    resources = [
+    resources = flatten([
       aws_ssm_parameter.secrets_notifications_slack_token.arn,
-    ]
+      values(aws_ssm_parameter.secrets_notifications_slack_webhook_urls)[*].arn
+    ])
   }
 
   statement {

--- a/locals_notifications.tf
+++ b/locals_notifications.tf
@@ -2,6 +2,9 @@ locals {
   notifications_configuration = jsonencode({
     slack = {
       apiToken = "awsssm://${aws_ssm_parameter.secrets_notifications_slack_token.name}"
+      slackIncomingWebhooks = {
+        for k, v in var.slack_incoming_webhook_urls : k => { webhookUrl = "awsssm:///${var.ssm_parameter_prefix}/secrets/notifications/slackIncomingWebhooks/${k}/webhookUrl" }
+      }
     }
   })
 }

--- a/locals_notifications.tf
+++ b/locals_notifications.tf
@@ -2,9 +2,9 @@ locals {
   notifications_configuration = jsonencode({
     slack = {
       apiToken = "awsssm://${aws_ssm_parameter.secrets_notifications_slack_token.name}"
-      slackIncomingWebhooks = {
-        for k, v in var.slack_incoming_webhook_urls : k => { webhookUrl = "awsssm:///${var.ssm_parameter_prefix}/secrets/notifications/slackIncomingWebhooks/${k}/webhookUrl" }
-      }
+    }
+    slackIncomingWebhooks = {
+      for k, v in var.slack_incoming_webhook_urls : k => { webhookUrl = "awsssm:///${var.ssm_parameter_prefix}/secrets/notifications/slackIncomingWebhooks/${k}/webhookUrl" }
     }
   })
 }

--- a/ssm_parameter_secrets_slack_webhook_urls.tf
+++ b/ssm_parameter_secrets_slack_webhook_urls.tf
@@ -1,8 +1,8 @@
 resource "aws_ssm_parameter" "secrets_notifications_slack_webhook_urls" {
-  for_each = var.slack_incoming_webhook_urls
+  for_each = nonsensitive(toset(keys(var.slack_incoming_webhook_urls)))
   name     = "/${var.ssm_parameter_prefix}/secrets/notifications/slackIncomingWebhooks/${each.key}/webhookUrl"
   type     = "SecureString"
-  value    = each.value
+  value    = var.slack_incoming_webhook_urls[each.key]
   key_id   = module.kms_ssm.key_arn
 
   lifecycle {

--- a/ssm_parameter_secrets_slack_webhook_urls.tf
+++ b/ssm_parameter_secrets_slack_webhook_urls.tf
@@ -1,0 +1,20 @@
+resource "aws_ssm_parameter" "secrets_notifications_slack_webhook_urls" {
+  for_each = var.slack_incoming_webhook_urls
+  name     = "/${var.ssm_parameter_prefix}/secrets/notifications/slackIncomingWebhooks/${each.key}/webhookUrl"
+  type     = "SecureString"
+  value    = each.value
+  key_id   = module.kms_ssm.key_arn
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+
+  tags = merge(
+    local.default_tags,
+    {
+      Name = "${local.csi}-secrets-notifications-slack-webhook-url-${each.key}",
+    }
+  )
+}

--- a/ssm_parameter_secrets_slack_webhook_urls.tf
+++ b/ssm_parameter_secrets_slack_webhook_urls.tf
@@ -1,8 +1,8 @@
 resource "aws_ssm_parameter" "secrets_notifications_slack_webhook_urls" {
-  for_each = nonsensitive(toset(keys(var.slack_incoming_webhook_urls)))
+  for_each = var.slack_incoming_webhook_urls
   name     = "/${var.ssm_parameter_prefix}/secrets/notifications/slackIncomingWebhooks/${each.key}/webhookUrl"
   type     = "SecureString"
-  value    = var.slack_incoming_webhook_urls[each.key]
+  value    = var.slack_webhook_initial_secret_value
   key_id   = module.kms_ssm.key_arn
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,14 @@ variable "slack_token_initial_secret_value" {
   default     = "CHANGEME"
 }
 
+variable "slack_incoming_webhook_urls" {
+  type        = map(string)
+  description = "Slack incoming webhook URLs"
+  default     = {}
+  sensitive   = true
+}
+
+
 # Identity Provider (General)
 
 variable "administrator_group_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -90,10 +90,15 @@ variable "slack_token_initial_secret_value" {
 }
 
 variable "slack_incoming_webhook_urls" {
-  type        = map(string)
+  type        = set(string)
   description = "Slack incoming webhook URLs"
-  default     = {}
-  sensitive   = true
+  default     = []
+}
+
+variable "slack_webhook_initial_secret_value" {
+  type        = string
+  description = "Initial Value for the SSM Parameter Store Parameter storing a Slack Webhook URL secret"
+  default     = "CHANGEME"
 }
 
 


### PR DESCRIPTION
Adds support for Slack Incoming Webhooks (our relevant docs page [here](https://docs.commonfate.io/common-fate/configuration/slack#setup-instructions---slack-webhooks))

Example configuration:

```hcl
slack_incoming_webhook_urls = ["channel_name"]
```

Verified working by creating a test Access Request in a demo deployment created using the Terraform module.