### PR TITLE
Fixing S3 buckets ACL error

### DIFF
--- a/module_s3bucket_frontend.tf
+++ b/module_s3bucket_frontend.tf
@@ -19,4 +19,6 @@ module "s3bucket_frontend" {
   }
 
   default_tags = local.default_tags
+
+  object_ownership = "BucketOwnerPreferred"
 }

--- a/modules/s3bucket/s3_bucket_acl.tf
+++ b/modules/s3bucket/s3_bucket_acl.tf
@@ -1,4 +1,5 @@
 resource "aws_s3_bucket_acl" "main" {
   bucket = aws_s3_bucket.main.id
   acl    = var.acl
+  depends_on = [aws_s3_bucket_ownership_controls.main]
 }

--- a/modules/s3bucket/s3_bucket_ownership_controls.tf
+++ b/modules/s3bucket/s3_bucket_ownership_controls.tf
@@ -4,6 +4,4 @@ resource "aws_s3_bucket_ownership_controls" "main" {
   rule {
     object_ownership = var.object_ownership
   }
-
-  depends_on = [ aws_s3_bucket_acl.main ]
 }


### PR DESCRIPTION
AWS updated that as of April 2023, [S3 buckets would have ACls disabled by default](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/) which was causing the error. 

Solution Reference: [link](https://stackoverflow.com/questions/76049290/error-accesscontrollistnotsupported-when-trying-to-create-a-bucket-acl-in-aws)